### PR TITLE
Raise error when name is missing for variable.

### DIFF
--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -180,6 +180,8 @@ namespace Obfuscar
                     else
                         project.vars.Remove(name);
                 }
+                else
+                    throw new ArgumentNullException("name");
             }
 
             var includes = reader.Elements("Include");


### PR DESCRIPTION
During integration of Obfuscar into our build environment, we ran into a problem by which variables were not being picked up.

The current version of Obfuscar reported no issue, and the values of the variables were not listed on console.

Actual problem was that the code our build environment uses was "Name" instead of "name". Stupid typo, but given the complexity of our build environment it had me puzzling for some time.

Since name must have a value, raise an exception is meaningful as it early alerts the user for an error in his XML.