### PR TITLE
Don't hide strings on methods where Exclude = True and ApplyToMember = True.

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -945,6 +945,14 @@ namespace Obfuscar
             if (skipStringHiding.IsMatch(method, map))
                 return true;
 
+            //
+            // Check if Exclude = true and ApplyToMembers is set on the owning method.
+            //
+            if (!(method.Method.MarkedToRename(true) ?? true))
+            {
+                return true;
+            }
+
             return !projectHideStrings;
         }
 


### PR DESCRIPTION
Currently method bodies which have Exclude = True on them are still obfuscated.

This pull request will exclude method bodies when Exclude = True and ApplyToMember = True.