### PR TITLE
Added ability to use filter for modules

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -75,31 +75,12 @@ namespace Obfuscar
             return def.Name.PublicKeyToken.Length != 0;
         }
 
-        public static IEnumerable<AssemblyInfo> FromXml(Project project, XElement reader, Variables vars)
-        {
-            string val = Helper.GetAttribute(reader, "file", vars);
-            if (string.IsNullOrWhiteSpace(val))
-                throw new InvalidOperationException("Need valid file attribute.");
-            var filter = Filter.TryGetFilter(project.Settings.InPath, val);
-            if (filter != null)
-            {
-                foreach (var file in filter)
-                {
-                    yield return FromXml(project, reader, file, vars);
-                }
-            }
-            else
-            {
-                yield return FromXml(project, reader, val, vars);
-            }
-        }
-
-        private static AssemblyInfo FromXml(Project project, XElement reader, string val, Variables vars)
+        public static AssemblyInfo FromXml(Project project, XElement reader, string file, Variables vars)
         {
             AssemblyInfo info = new AssemblyInfo(project);
 
             // pull out the file attribute, but don't process anything empty
-            info.LoadAssembly(val);
+            info.LoadAssembly(file);
 
             string isExcluded = Helper.GetAttribute(reader, "Exclude", vars);
             if ((isExcluded.Length > 0) && (isExcluded.ToLowerInvariant() == "true"))

--- a/Obfuscar/Filter.cs
+++ b/Obfuscar/Filter.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Obfuscar
+{
+    internal class Filter : IEnumerable<string>
+    {
+        private static readonly Regex _patternRegex = new Regex(@"(?<sign>[\+\-])\[(?<pattern>(?>\[(?<c>)|[^\[\]]+|\](?<-c>))*(?(c)(?!)))\]", RegexOptions.Compiled);
+        private static readonly char[] signs = new[] { '+', '-' };
+        private static readonly char[] directorySeparators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        private readonly IList<string> inclusions, exclusions;
+        private readonly string path;
+
+        private Filter(string path, IList<string> inclusions, IList<string> exclusions)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("message", nameof(path));
+            }
+
+            this.path = path;
+            this.inclusions = inclusions ?? throw new ArgumentNullException(nameof(inclusions));
+            this.exclusions = exclusions ?? throw new ArgumentNullException(nameof(exclusions));
+        }
+
+        public static Filter TryGetFilter(string path, string filter)
+        {
+            if ((filter?.IndexOfAny(signs) ?? -1) == -1)
+            {
+                return null;
+            }
+            var matches = _patternRegex.Matches(filter);
+            if (matches.Count == 0)
+            {
+                return null;
+            }
+            var inclusions = new List<string>();
+            var exclusions = new List<string>();
+            foreach (var match in matches.Cast<Match>())
+            {
+                var sign = match.Groups["sign"].Value[0];
+                var list = sign == '+' ? inclusions : exclusions;
+
+                var pattern = match.Groups["pattern"].Value;
+                list.Add(pattern);
+            }
+            return new Filter(path, inclusions, exclusions);
+        }
+
+        public IEnumerator<string> GetEnumerator() => GetFiles().GetEnumerator();
+
+        private IEnumerable<string> GetFiles()
+        {
+            var excluded = new HashSet<string>(exclusions.SelectMany(GetFiles), StringComparer.Ordinal);
+            return inclusions.SelectMany(GetFiles).Where(file => !excluded.Contains(file));
+        }
+
+        private IEnumerable<string> GetFiles(string pattern)
+        {
+            var lastSeparator = pattern.LastIndexOfAny(directorySeparators);
+            var searchPath = lastSeparator != -1 ?
+                Path.GetFullPath(Path.Combine(path, pattern.Substring(0, lastSeparator))) :
+                path;
+            var filePattern = lastSeparator != -1 ?
+                pattern.Substring(lastSeparator + 1) :
+                pattern;
+            return Directory.EnumerateFiles(searchPath, filePattern);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Obfuscar/Filter.cs
+++ b/Obfuscar/Filter.cs
@@ -10,13 +10,11 @@ namespace Obfuscar
 {
     internal class Filter : IEnumerable<string>
     {
-        private static readonly Regex _patternRegex = new Regex(@"(?<sign>[\+\-])\[(?<pattern>(?>\[(?<c>)|[^\[\]]+|\](?<-c>))*(?(c)(?!)))\]", RegexOptions.Compiled);
-        private static readonly char[] signs = new[] { '+', '-' };
         private static readonly char[] directorySeparators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
         private readonly IList<string> inclusions, exclusions;
         private readonly string path;
 
-        private Filter(string path, IList<string> inclusions, IList<string> exclusions)
+        public Filter(string path, IList<string> inclusions, IList<string> exclusions)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -26,30 +24,6 @@ namespace Obfuscar
             this.path = path;
             this.inclusions = inclusions ?? throw new ArgumentNullException(nameof(inclusions));
             this.exclusions = exclusions ?? throw new ArgumentNullException(nameof(exclusions));
-        }
-
-        public static Filter TryGetFilter(string path, string filter)
-        {
-            if ((filter?.IndexOfAny(signs) ?? -1) == -1)
-            {
-                return null;
-            }
-            var matches = _patternRegex.Matches(filter);
-            if (matches.Count == 0)
-            {
-                return null;
-            }
-            var inclusions = new List<string>();
-            var exclusions = new List<string>();
-            foreach (var match in matches.Cast<Match>())
-            {
-                var sign = match.Groups["sign"].Value[0];
-                var list = sign == '+' ? inclusions : exclusions;
-
-                var pattern = match.Groups["pattern"].Value;
-                list.Add(pattern);
-            }
-            return new Filter(path, inclusions, exclusions);
         }
 
         public IEnumerator<string> GetEnumerator() => GetFiles().GetEnumerator();

--- a/Obfuscar/Obfuscar.csproj
+++ b/Obfuscar/Obfuscar.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
     <PackageReference Include="Rollbar" Version="3.2.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -198,16 +198,18 @@ namespace Obfuscar
             var modules = reader.Elements("Module");
             foreach (var module in modules)
             {
-                AssemblyInfo info = AssemblyInfo.FromXml(project, module, project.vars);
-                if (info.Exclude)
+                foreach (var info in AssemblyInfo.FromXml(project, module, project.vars))
                 {
-                    project.CopyAssemblyList.Add(info);
-                    break;
-                }
+                    if (info.Exclude)
+                    {
+                        project.CopyAssemblyList.Add(info);
+                        break;
+                    }
 
-                Console.WriteLine("Processing assembly: " + info.Definition.Name.FullName);
-                project.AssemblyList.Add(info);
-                project.assemblyMap[info.Name] = info;
+                    Console.WriteLine("Processing assembly: " + info.Definition.Name.FullName);
+                    project.AssemblyList.Add(info);
+                    project.assemblyMap[info.Name] = info;
+                }
             }
         }
 

--- a/Tests/FilterTests.cs
+++ b/Tests/FilterTests.cs
@@ -1,0 +1,72 @@
+﻿using Obfuscar;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ObfuscarTests
+{
+    public class FilterTests
+    {
+        [Theory]
+        [InlineData("+[XXX]", true)]
+        [InlineData("-[XXX]", true)]
+        [InlineData("+[XXX] -[YYY]", true)]
+        [InlineData("[XXX]", false)]
+        public void IsFilter(string value, bool expected)
+        {
+            Assert.Equal(expected, Filter.TryGetFilter(Environment.CurrentDirectory, value) != null);
+        }
+
+        [Fact]
+        public void FullPaths()
+        {
+            // Arrange
+            var sut = Filter.TryGetFilter(Environment.CurrentDirectory, $"+[{Path.Combine(Environment.CurrentDirectory, "*.*")}]");
+
+            // Act
+            var files = sut.ToList();
+
+            // Assert
+            Assert.Equal(
+                Directory.EnumerateFiles(Environment.CurrentDirectory, "*.*").Select(f => Path.GetFullPath(f)),
+                files);
+        }
+
+        [Fact]
+        public void RelativePaths()
+        {
+            // Arrange
+            var backAndForthRelativePath = Path.Combine("..", Path.GetFileName(Environment.CurrentDirectory));
+            var sut = Filter.TryGetFilter(".", $"+[{Path.Combine(backAndForthRelativePath, "*.*")}]");
+
+            // Act
+            var files = sut.ToList();
+
+            // Assert
+            Assert.Equal(
+                Directory.EnumerateFiles(Environment.CurrentDirectory, "*.*").Select(f => Path.GetFullPath(f)),
+                files);
+        }
+
+        [Fact]
+        public void Exclusion()
+        {
+            // Arrange
+            var expected = Directory.EnumerateFiles(Environment.CurrentDirectory, "*.*").Select(f => Path.GetFullPath(f)).ToList();
+            var backAndForthRelativePath = Path.Combine("..", Path.GetFileName(Environment.CurrentDirectory));
+            var oneFile = expected[0];
+            expected.RemoveAt(0);
+            var sut = Filter.TryGetFilter(".", $"+[{Path.Combine(backAndForthRelativePath, "*.*")}] -[{oneFile}]");
+
+            // Act
+            var files = sut.ToList();
+
+            // Assert
+            Assert.Equal(expected, files);
+        }
+    }
+}

--- a/Tests/FilterTests.cs
+++ b/Tests/FilterTests.cs
@@ -11,21 +11,14 @@ namespace ObfuscarTests
 {
     public class FilterTests
     {
-        [Theory]
-        [InlineData("+[XXX]", true)]
-        [InlineData("-[XXX]", true)]
-        [InlineData("+[XXX] -[YYY]", true)]
-        [InlineData("[XXX]", false)]
-        public void IsFilter(string value, bool expected)
-        {
-            Assert.Equal(expected, Filter.TryGetFilter(Environment.CurrentDirectory, value) != null);
-        }
-
         [Fact]
         public void FullPaths()
         {
             // Arrange
-            var sut = Filter.TryGetFilter(Environment.CurrentDirectory, $"+[{Path.Combine(Environment.CurrentDirectory, "*.*")}]");
+            var sut = new Filter(
+                Environment.CurrentDirectory,
+                new[] { Path.Combine(Environment.CurrentDirectory, "*.*") },
+                new string[0]);
 
             // Act
             var files = sut.ToList();
@@ -41,7 +34,10 @@ namespace ObfuscarTests
         {
             // Arrange
             var backAndForthRelativePath = Path.Combine("..", Path.GetFileName(Environment.CurrentDirectory));
-            var sut = Filter.TryGetFilter(".", $"+[{Path.Combine(backAndForthRelativePath, "*.*")}]");
+            var sut = new Filter(
+                Environment.CurrentDirectory,
+                new[] { Path.Combine(backAndForthRelativePath, "*.*") },
+                new string[0]);
 
             // Act
             var files = sut.ToList();
@@ -60,7 +56,10 @@ namespace ObfuscarTests
             var backAndForthRelativePath = Path.Combine("..", Path.GetFileName(Environment.CurrentDirectory));
             var oneFile = expected[0];
             expected.RemoveAt(0);
-            var sut = Filter.TryGetFilter(".", $"+[{Path.Combine(backAndForthRelativePath, "*.*")}] -[{oneFile}]");
+            var sut = new Filter(
+                Environment.CurrentDirectory,
+                new[] { Path.Combine(backAndForthRelativePath, "*.*") },
+                new[] { oneFile });
 
             // Act
             var files = sut.ToList();

--- a/Tests/ObfuscarTests.csproj
+++ b/Tests/ObfuscarTests.csproj
@@ -57,6 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyHelper.cs" />
+    <Compile Include="FilterTests.cs" />
     <Compile Include="InterfaceTests.cs" />
     <Compile Include="SettingsTests.cs" />
     <Compile Include="CleanPoolTests.cs" />


### PR DESCRIPTION
We are obfuscating a number of assemblies. When developers are adding a new project we need to declare these new projects in the configuration file.

This PR adds as a way to define multiple files at once without having to duplicate lines in the configuration. Also, as most company assemblies are following a convention Acme.XXX.dll, declaring how they should be obfuscated in one line is much more efficient.

```
<Module file="$(InPath)\SomeFile.dll">
    <Include path="obfuscar.skip.xml" />
</Module>
<Modules>
   <IncludeFiles>$(InPath)\Acme.*.dll</IncludeFiles>
   <ExcludeFiles>$(InPath)\Acme*Tests.dll</ExcludeFiles>
   <Include path="obfuscar.skip.xml" />
</Modules>
```