### PR TITLE
Optionally skip serializable types from obfuscation

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -2,17 +2,17 @@
 
 /// <copyright>
 /// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
-/// 
+///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
 /// in the Software without restriction, including without limitation the rights
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -781,8 +781,14 @@ namespace Obfuscar
         }
 
         public bool ShouldSkip(TypeKey type, InheritMap map, bool keepPublicApi, bool hidePrivateApi, bool markedOnly,
-            out string message)
+            bool skipSerializableTypes, out string message)
         {
+            if (skipSerializableTypes && type.TypeDefinition.IsSerializable)
+            {
+                message = "SkipSerializableTypes option in configuration";
+                return true;
+            }
+
             var attribute = type.TypeDefinition.MarkedToRename();
             if (attribute != null)
             {
@@ -949,8 +955,18 @@ namespace Obfuscar
         }
 
         public bool ShouldSkip(FieldKey field, InheritMap map, bool keepPublicApi, bool hidePrivateApi, bool markedOnly,
-            out string message)
+            bool skipSerializableTypes, out string message)
         {
+            if (skipSerializableTypes && field.DeclaringType.IsSerializable)
+            {
+                bool nonSerialized = field.FieldAttributes.HasFlag(FieldAttributes.NotSerialized);
+                if (!nonSerialized)
+                {
+                    message = "SkipSerializableTypes option in configuration";
+                    return true;
+                }
+            }
+
             // skip runtime methods
             if ((field.Field.IsRuntimeSpecialName && field.Field.Name == "value__"))
             {
@@ -1019,8 +1035,14 @@ namespace Obfuscar
         }
 
         public bool ShouldSkip(PropertyKey prop, InheritMap map, bool keepPublicApi, bool hidePrivateApi,
-            bool markedOnly, out string message)
+            bool markedOnly, bool skipSerializableTypes, out string message)
         {
+            if (skipSerializableTypes && prop.DeclaringType.IsSerializable)
+            {
+                message = "SkipSerializableTypes option in configuration";
+                return true;
+            }
+
             if (prop.Property.IsRuntimeSpecialName)
             {
                 message = "runtime special name";

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -413,7 +413,9 @@ namespace Obfuscar
             string skip;
             if (info.ShouldSkip(fieldKey, Project.InheritMap, Project.Settings.KeepPublicApi,
                 Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+                Project.Settings.MarkedOnly,
+                Project.Settings.SkipSerializableTypes,
+                out skip))
             {
                 Mapping.UpdateField(fieldKey, ObfuscationStatus.Skipped, skip);
                 nameGroup.Add(fieldKey.Name);
@@ -478,7 +480,7 @@ namespace Obfuscar
                     string skip;
                     // rename the class parameters
                     if (info.ShouldSkip(new TypeKey(type), Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, Project.Settings.SkipSerializableTypes, out skip))
                         continue;
 
                     int index = 0;
@@ -544,7 +546,7 @@ namespace Obfuscar
 
                     string skip;
                     if (info.ShouldSkip(unrenamedTypeKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, Project.Settings.SkipSerializableTypes, out skip))
                     {
                         Mapping.UpdateType(oldTypeKey, ObfuscationStatus.Skipped, skip);
 
@@ -863,7 +865,9 @@ namespace Obfuscar
             // skip filtered props
             if (info.ShouldSkip(propKey, Project.InheritMap, Project.Settings.KeepPublicApi,
                 Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+                Project.Settings.MarkedOnly,
+                Project.Settings.SkipSerializableTypes,
+                out skip))
             {
                 m.Update(ObfuscationStatus.Skipped, skip);
 

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -1015,7 +1015,7 @@ namespace Obfuscar
                     Dictionary<ParamSig, NameGroup> sigNames = GetSigNames(baseSigNames, typeKey);
 
                     // first pass.  mark grouped virtual methods to be renamed, and mark some things
-                    // to be skipped as neccessary
+                    // to be skipped as necessary
                     foreach (MethodDefinition method in type.Methods)
                     {
                         ProcessMethod(typeKey, method, info, baseSigNames);
@@ -1395,7 +1395,7 @@ namespace Obfuscar
                     }
 
                     // first pass.  mark grouped virtual methods to be renamed, and mark some things
-                    // to be skipped as neccessary
+                    // to be skipped as necessary
                     foreach (MethodDefinition method in type.Methods)
                     {
                         method.CleanAttributes();

--- a/Obfuscar/Settings.cs
+++ b/Obfuscar/Settings.cs
@@ -41,6 +41,7 @@ namespace Obfuscar
             RenameFields = XmlConvert.ToBoolean(vars.GetValue("RenameFields", "true"));
             RenameProperties = XmlConvert.ToBoolean(vars.GetValue("RenameProperties", "true"));
             RenameEvents = XmlConvert.ToBoolean(vars.GetValue("RenameEvents", "true"));
+            SkipSerializableTypes = XmlConvert.ToBoolean(vars.GetValue("SkipSerializableTypes", "false"));
             KeepPublicApi = XmlConvert.ToBoolean(vars.GetValue("KeepPublicApi", "true"));
             HidePrivateApi = XmlConvert.ToBoolean(vars.GetValue("HidePrivateApi", "true"));
             ReuseNames = XmlConvert.ToBoolean(vars.GetValue("ReuseNames", "true"));
@@ -69,6 +70,8 @@ namespace Obfuscar
         public bool RenameProperties { get; }
 
         public bool RenameEvents { get; }
+
+        public bool SkipSerializableTypes { get; }
 
         public bool KeepPublicApi { get; }
 

--- a/Tests/Input/AssemblyWithTypesAttrs3.cs
+++ b/Tests/Input/AssemblyWithTypesAttrs3.cs
@@ -36,6 +36,7 @@ namespace TestClasses
 
     [System.Reflection.ObfuscationAttribute(Exclude=false, ApplyToMembers=true, StripAfterObfuscation = true)]
     [System.Runtime.Serialization.DataContract]
+    [System.Serializable]
     public class PublicClass
     {
         public virtual void PublicMethod()
@@ -54,5 +55,14 @@ namespace TestClasses
 
         [System.Runtime.Serialization.DataMember(Name = "token_type")]
         public long TestLong { get; set; }
+
+        private int TestPrivateProperty { get; set; }
+
+        public int TestNonSerializedProperty { get; set; }
+
+        public int TestSerializedField;
+
+        [NonSerialized]
+        public int TestNonSerializedField;
     }
 }

--- a/Tests/ObfuscarTests.csproj
+++ b/Tests/ObfuscarTests.csproj
@@ -56,6 +56,32 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="Input\AssemblyA.cs" />
+    <None Include="Input\AssemblyB.cs" />
+    <None Include="Input\AssemblyForCleanPoolClass.cs" />
+    <None Include="Input\AssemblyForCleanPoolInterface.cs" />
+    <None Include="Input\AssemblyForSigning.cs" />
+    <None Include="Input\AssemblyForSigning2.cs" />
+    <None Include="Input\AssemblyWithAttrs.cs" />
+    <None Include="Input\AssemblyWithClosedOverrideGeneric.cs" />
+    <None Include="Input\AssemblyWithCustomAttr.cs" />
+    <None Include="Input\AssemblyWithCustomAttrTypeArg.cs" />
+    <None Include="Input\AssemblyWithEnums.cs" />
+    <None Include="Input\AssemblyWithEvents.cs" />
+    <None Include="Input\AssemblyWithGenericOverrides.cs" />
+    <None Include="Input\AssemblyWithGenericOverrides2.cs" />
+    <None Include="Input\AssemblyWithInterfaces.cs" />
+    <None Include="Input\AssemblyWithInterfaces2.cs" />
+    <None Include="Input\AssemblyWithNestedTypes.cs" />
+    <None Include="Input\AssemblyWithNestedTypes2.cs" />
+    <None Include="Input\AssemblyWithOverrides.cs" />
+    <None Include="Input\AssemblyWithProperties.cs" />
+    <None Include="Input\AssemblyWithSpecializedGenerics.cs" />
+    <None Include="Input\AssemblyWithStrings.cs" />
+    <None Include="Input\AssemblyWithTypes.cs" />
+    <None Include="Input\AssemblyWithTypesAttrs.cs" />
+    <None Include="Input\AssemblyWithTypesAttrs2.cs" />
+    <None Include="Input\AssemblyWithTypesAttrs3.cs" />
     <Compile Include="AssemblyHelper.cs" />
     <Compile Include="InterfaceTests.cs" />
     <Compile Include="SettingsTests.cs" />

--- a/Tests/ObfuscationAttributeTests.cs
+++ b/Tests/ObfuscationAttributeTests.cs
@@ -35,13 +35,33 @@ namespace ObfuscarTests
                 Assert.True(false, $"Unable to compile test assembly:  AssemblyB, {cr.Errors[0].ErrorText}");
         }
 
-        static MethodDefinition FindByName(TypeDefinition typeDef, string name)
+        static FieldDefinition FindField(TypeDefinition typeDef, string name)
+        {
+            foreach (FieldDefinition field in typeDef.Fields)
+                if (field.Name == name)
+                    return field;
+
+            Assert.True(false, string.Format("Expected to find field: {0}", name));
+            return null; // never here
+        }
+
+        static MethodDefinition FindMethod(TypeDefinition typeDef, string name)
         {
             foreach (MethodDefinition method in typeDef.Methods)
                 if (method.Name == name)
                     return method;
 
             Assert.True(false, string.Format("Expected to find method: {0}", name));
+            return null; // never here
+        }
+
+        static PropertyDefinition FindProperty(TypeDefinition typeDef, string name)
+        {
+            foreach (PropertyDefinition property in typeDef.Properties)
+                if (property.Name == name)
+                    return property;
+
+            Assert.True(false, string.Format("Expected to find property: {0}", name));
             return null; // never here
         }
 
@@ -68,7 +88,7 @@ namespace ObfuscarTests
             {
                 TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass");
                 ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-                var classAmethod1 = FindByName(classAType, "PublicMethod");
+                var classAmethod1 = FindMethod(classAType, "PublicMethod");
                 var method = map.GetMethod(new MethodKey(classAmethod1));
 
                 TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -88,7 +108,7 @@ namespace ObfuscarTests
             {
                 TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass3");
                 ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-                var classAmethod1 = FindByName(classAType, "PublicMethod");
+                var classAmethod1 = FindMethod(classAType, "PublicMethod");
                 var method = map.GetMethod(new MethodKey(classAmethod1));
 
                 TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -107,7 +127,7 @@ namespace ObfuscarTests
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethod(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -115,7 +135,7 @@ namespace ObfuscarTests
 
             TypeDefinition classCType = inAssmDef.MainModule.GetType("TestClasses.InternalClass2");
             ObfuscatedThing classC = map.GetClass(new TypeKey(classCType));
-            var classCmethod1 = FindByName(classCType, "PublicMethod");
+            var classCmethod1 = FindMethod(classCType, "PublicMethod");
             var method1 = map.GetMethod(new MethodKey(classCmethod1));
 
             TypeDefinition nestedClassBType = classCType.NestedTypes[0];
@@ -131,7 +151,7 @@ namespace ObfuscarTests
 
             TypeDefinition classDType = inAssmDef.MainModule.GetType("TestClasses.PublicClass2");
             ObfuscatedThing classD = map.GetClass(new TypeKey(classDType));
-            var classDmethod1 = FindByName(classDType, "PublicMethod");
+            var classDmethod1 = FindMethod(classDType, "PublicMethod");
             var method3 = map.GetMethod(new MethodKey(classDmethod1));
 
             Assert.True(classD.Status == ObfuscationStatus.Skipped, "PublicClass2 shouldn't have been obfuscated.");
@@ -226,7 +246,7 @@ namespace ObfuscarTests
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethod(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -271,7 +291,7 @@ namespace ObfuscarTests
 
             TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass");
             ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-            var classAmethod1 = FindByName(classAType, "PublicMethod");
+            var classAmethod1 = FindMethod(classAType, "PublicMethod");
             var method = map.GetMethod(new MethodKey(classAmethod1));
 
             TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -288,7 +308,7 @@ namespace ObfuscarTests
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethod(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -296,7 +316,7 @@ namespace ObfuscarTests
 
             TypeDefinition classCType = inAssmDef.MainModule.GetType("TestClasses.InternalClass2");
             ObfuscatedThing classC = map.GetClass(new TypeKey(classCType));
-            var classCmethod1 = FindByName(classCType, "PublicMethod");
+            var classCmethod1 = FindMethod(classCType, "PublicMethod");
             var method1 = map.GetMethod(new MethodKey(classCmethod1));
 
             TypeDefinition nestedClassBType = classCType.NestedTypes[0];
@@ -314,11 +334,66 @@ namespace ObfuscarTests
 
             TypeDefinition classDType = inAssmDef.MainModule.GetType("TestClasses.PublicClass2");
             ObfuscatedThing classD = map.GetClass(new TypeKey(classDType));
-            var classDmethod1 = FindByName(classDType, "PublicMethod");
+            var classDmethod1 = FindMethod(classDType, "PublicMethod");
             var method3 = map.GetMethod(new MethodKey(classDmethod1));
 
             Assert.True(classD.Status == ObfuscationStatus.Skipped, "PublicClass2 shouldn't have been obfuscated.");
             Assert.True(method3.Status == ObfuscationStatus.Renamed, "PublicMethod should have been obfuscated.");
+        }
+
+        [Fact]
+        public void CheckSkipSerializableTypes()
+        {
+            string name = "AssemblyWithTypesAttrs3";
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"  <Var name='InPath' value='{0}' />" +
+                @"  <Var name='OutPath' value='{1}' />" +
+                @"  <Var name='KeepPublicApi' value='false' />" +
+                @"  <Var name='HidePrivateApi' value='true' />" +
+                @"  <Var name='SkipSerializableTypes' value='true' />" +
+                @"  <Module file='$(InPath){2}{3}.dll' />" +
+                @"</Obfuscator>",
+                TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar, name);
+
+            var obfuscator = TestHelper.BuildAndObfuscate(name, string.Empty, xml);
+            var map = obfuscator.Mapping;
+
+            AssemblyDefinition inAssmDef = AssemblyDefinition.ReadAssembly(obfuscator.Project.AssemblyList[0].FileName);
+
+            TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.TestEnum");
+            ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
+            Assert.Equal(ObfuscationStatus.Renamed, classA.Status);
+
+            var enumField = classAType.Fields.FirstOrDefault(item => item.Name == "Default");
+            var f1 = map.GetField(new FieldKey(enumField));
+            Assert.Equal(ObfuscationStatus.Renamed, f1.Status);
+
+            var enumField2 = classAType.Fields.FirstOrDefault(item => item.Name == "Test");
+            var f2 = map.GetField(new FieldKey(enumField2));
+            Assert.Equal(ObfuscationStatus.Renamed, f2.Status);
+
+            TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
+            var classBTypeKey = new TypeKey(classBType);
+            ObfuscatedThing classB = map.GetClass(classBTypeKey);
+            Assert.Equal(ObfuscationStatus.Skipped, classB.Status);
+
+            var classBmethod1 = FindMethod(classBType, "PublicMethod");
+            var method1 = map.GetMethod(new MethodKey(classBmethod1));
+            Assert.Equal(ObfuscationStatus.Renamed, method1.Status);
+
+            var classBproperty1 = FindProperty(classBType, "TestInt");
+            var property1 = map.GetProperty(new PropertyKey(classBTypeKey, classBproperty1));
+            Assert.Equal(ObfuscationStatus.Skipped, property1.Status);
+
+            var classBfield1 = FindField(classBType, "TestSerializedField");
+            var field1 = map.GetField(new FieldKey(classBfield1));
+            Assert.Equal(ObfuscationStatus.Skipped, field1.Status);
+
+            var classBfield2 = FindField(classBType, "TestNonSerializedField");
+            var field2 = map.GetField(new FieldKey(classBfield2));
+            Assert.Equal(ObfuscationStatus.Renamed, field2.Status);
         }
     }
 }

--- a/Tests/ObfuscationAttributeTests.cs
+++ b/Tests/ObfuscationAttributeTests.cs
@@ -193,7 +193,7 @@ namespace ObfuscarTests
         }
 
         [Fact]
-        public void CheckMakedOnly()
+        public void CheckMarkedOnly()
         {
             string name = "AssemblyWithTypesAttrs3";
             string xml = string.Format(
@@ -236,9 +236,9 @@ namespace ObfuscarTests
             TypeDefinition classTypeRenamed = outAssmDef.MainModule.Types[2];
             Assert.False(classTypeRenamed.CustomAttributes.Count == 2, "obfuscation attribute on type should have been removed.");
             MethodDefinition testMethod = classTypeRenamed.Methods.First(_ => _.Name == "Test");
-            Assert.False(testMethod.HasCustomAttributes, "obfuscattion attribute on method should have been removed.");
+            Assert.False(testMethod.HasCustomAttributes, "obfuscation attribute on method should have been removed.");
             MethodDefinition test2Method = classTypeRenamed.Methods.First(_ => _.Name == "Test2");
-            Assert.True(test2Method.HasCustomAttributes, "obfuscattion attribute on method should not have been removed.");
+            Assert.True(test2Method.HasCustomAttributes, "obfuscation attribute on method should not have been removed.");
 
             PropertyDefinition token = classTypeRenamed.Properties[0];
             Assert.Equal("access_token", token.CustomAttributes[0].Properties[0].Argument.Value);

--- a/Tests/TesterTests.cs
+++ b/Tests/TesterTests.cs
@@ -60,7 +60,7 @@ namespace ObfuscarTests
 
             Obfuscar.IPredicate<Obfuscar.PropertyKey> tester;
 
-            // check differnt kinds of name
+            // check different kinds of name
             tester = new Obfuscar.PropertyTester("property", "ns.name", "public", null);
             Assert.True(tester.Test(key), "Tester should handle strings.");
             tester = new Obfuscar.PropertyTester("pr*ty", "ns.name", "public", null);
@@ -70,7 +70,7 @@ namespace ObfuscarTests
             tester = new Obfuscar.PropertyTester(new Regex("p.*y"), "ns.name", "public", null);
             Assert.True(tester.Test(key), "Tester should handle regular expressions.");
 
-            // check differnt kinds of type name
+            // check different kinds of type name
             tester = new Obfuscar.PropertyTester("property", "ns.n*e", "public", null);
             Assert.True(tester.Test(key), "Tester should handle type wildcards.");
             tester = new Obfuscar.PropertyTester("property", "^ns\\.n.*e", "public", null);
@@ -87,7 +87,7 @@ namespace ObfuscarTests
 
             Obfuscar.IPredicate<Obfuscar.MethodKey> tester;
 
-            // check differnt kinds of name
+            // check different kinds of name
             tester = new Obfuscar.MethodTester("method", "ns.name", "", "");
             Assert.True(tester.Test(key), "Tester should handle strings.");
             tester = new Obfuscar.MethodTester("me*od", "ns.name", "", "");
@@ -97,7 +97,7 @@ namespace ObfuscarTests
             tester = new Obfuscar.MethodTester(new Regex("me.*od"), "ns.name", "", "");
             Assert.True(tester.Test(key), "Tester should handle regular expressions.");
 
-            // check differnt kinds of type name
+            // check different kinds of type name
             tester = new Obfuscar.MethodTester("method", "ns.n*e", "", "");
             Assert.True(tester.Test(key), "Tester should handle type wildcards.");
             tester = new Obfuscar.MethodTester("method", "^ns\\.n.*e", "", "");
@@ -117,7 +117,7 @@ namespace ObfuscarTests
 
             Obfuscar.IPredicate<Obfuscar.FieldKey> tester;
 
-            // check differnt kinds of name
+            // check different kinds of name
             tester = new Obfuscar.FieldTester("field", "ns.name", "", "", "", "", false, false);
             Assert.True(tester.Test(key), "Tester should handle strings.");
             tester = new Obfuscar.FieldTester("f*d", "ns.name", "", "", "", "", false, false);
@@ -127,7 +127,7 @@ namespace ObfuscarTests
             tester = new Obfuscar.FieldTester(new Regex("f.*d"), "ns.name", "", "", "", "", false, false);
             Assert.True(tester.Test(key), "Tester should handle regular expressions.");
 
-            // check differnt kinds of type name
+            // check different kinds of type name
             tester = new Obfuscar.FieldTester("field", "ns.n*e", "", "", "", "", false, false);
             Assert.True(tester.Test(key), "Tester should handle type wildcards.");
             tester = new Obfuscar.FieldTester("field", "^ns\\.n.*e", "", "", "", "", false, false);
@@ -144,7 +144,7 @@ namespace ObfuscarTests
 
             Obfuscar.IPredicate<Obfuscar.EventKey> tester;
 
-            // check differnt kinds of name
+            // check different kinds of name
             tester = new Obfuscar.EventTester("event", "ns.name", "", "");
             Assert.True(tester.Test(key), "Tester should handle strings.");
             tester = new Obfuscar.EventTester("e*t", "ns.name", "", "");
@@ -154,7 +154,7 @@ namespace ObfuscarTests
             tester = new Obfuscar.EventTester(new Regex("e.*t"), "ns.name", "", "");
             Assert.True(tester.Test(key), "Tester should handle regular expressions.");
 
-            // check differnt kinds of type name
+            // check different kinds of type name
             tester = new Obfuscar.EventTester("event", "ns.n*e", "", "");
             Assert.True(tester.Test(key), "Tester should handle type wildcards.");
             tester = new Obfuscar.EventTester("event", "^ns\\.n.*e", "", "");


### PR DESCRIPTION
I'm obfuscating a project with a large number of types marked with the Serializable attribute that need to be skipped from obfuscation. Some of them are generated, and I don't have control of the generator to alter the attributes. For these cases, having an option to skip the serializable types seems desirable.