### PR TITLE
Fixes #288: Keep assembly delay-signed if Key is not provided

### DIFF
--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -265,6 +265,13 @@ namespace Obfuscar
                                 info.OutputFileName = outName;
                             }
                         }
+                        else if (!info.Definition.MainModule.Attributes.HasFlag(ModuleAttributes.StrongNameSigned))
+                        {
+                            // When an assembly is "delay signed" and no KeyFile or KeyContainer properties were provided,
+                            // keep the obfuscated assembly "delay signed" too.
+                            info.Definition.Write(outName, parameters);
+                            info.OutputFileName = outName;
+                        }
                         else
                         {
                             throw new ObfuscarException($"Obfuscating a signed assembly would result in an invalid assembly:  {info.Name}; use the KeyFile or KeyContainer property to set a key to use");

--- a/Tests/SigningTests.cs
+++ b/Tests/SigningTests.cs
@@ -177,5 +177,38 @@ namespace ObfuscarTests
                 AssemblyDefinition.ReadAssembly(Path.Combine(outputPath, "DelaySigned.dll"));
             Assert.False(outAssmDef.MainModule.Attributes.HasFlag(ModuleAttributes.StrongNameSigned));
         }
+
+        [Fact]
+        public void DelaySignedRemainsWhenNoKeyProvided()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepPublicApi' value='false' />" +
+                @"<Module file='$(InPath){2}DelaySigned.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            TestHelper.CleanInput();
+            var assembly = Path.Combine(TestHelper.InputPath, "DelaySigned.dll");
+
+            // build it with the keyfile option (embeds the public key, and signs the assembly)
+            if (!File.Exists(assembly))
+            {
+                File.Copy(Path.Combine(TestHelper.InputPath, @"..", "DelaySigned.dll"), assembly, true);
+            }
+
+            var map = TestHelper.Obfuscate(xml).Mapping;
+
+            AssemblyDefinition inAssmDef = AssemblyDefinition.ReadAssembly(assembly);
+            Assert.False(inAssmDef.MainModule.Attributes.HasFlag(ModuleAttributes.StrongNameSigned));
+
+            AssemblyDefinition outAssmDef =
+                AssemblyDefinition.ReadAssembly(Path.Combine(outputPath, "DelaySigned.dll"));
+            Assert.False(outAssmDef.MainModule.Attributes.HasFlag(ModuleAttributes.StrongNameSigned));
+        }
     }
 }


### PR DESCRIPTION
When an original assembly is "delay signed" and there is no `KeyFile` or `KeyContainer` property specified in `obfuscar.xml` - Obfuscar should still perform obfuscation and keep the PublicKey embedded into the assembly as is. Thus, the obfuscated assembly remains to be "delay signed".

This change simplifies configuration for scenarios when final signing is handled outside of the build process, by removing requirement of providing a PublicKey, since it's already stored in an assembly. It also makes possible to perform obfuscation of "delay signed" assemblies on MacOS (previously it failed because of the not supported PublicKey-related API, see #288 for more details).