### PR TITLE
Hotfix for Linux: Update obfuscar.props

### DIFF
--- a/build/obfuscar.props
+++ b/build/obfuscar.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Obfuscar>$(MSBuildThisFileDirectory)..\tools\obfuscar.console.exe</Obfuscar>
+    <Obfuscar>$(MSBuildThisFileDirectory)..\tools\Obfuscar.Console.exe</Obfuscar>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Linux is a case sensitive in files not like windows. It fails if you use this project in a Linux. This is a hot fix. 
I got an failed build using msbuild with mono-devel in jenkins 

`
/var/lib/jenkins/workspace/pipe1/project/Directory.Build.targets(62,5): error MSB3073: The command "mono /var/lib/jenkins/.nuget/packages/obfuscar/2.2.28/build/../tools/obfuscar.console.exe -s obfuscar/obfuscar-build-server.xml" exited with code 2. [/var/lib/jenkins/workspace/pipe1/project/project.csproj]
`

The fix propose to edit the file obfuscar.props with the right file name. Because Linux is case sensitive