### PR TITLE
Fix #268: NotSupportedException for WinForms in .NET Core 3.1 and later

### DIFF
--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -729,6 +729,10 @@ namespace Obfuscar
                 {
                     continue;
                 }
+                catch (NotSupportedException)
+                {
+                    continue;
+                }
 
                 foreach (DictionaryEntry entry in reader.Cast<DictionaryEntry>().OrderBy(e => e.Key.ToString()))
                 {


### PR DESCRIPTION
Swallow NotSupportedException in GetXamlDocuments for resources in
localized WinForms applications in .Net Core 3.1 and later.