### PR TITLE
Fixes #276

### DIFF
--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -1589,6 +1589,9 @@ namespace Obfuscar
                 if (_disabled)
                     return;
 
+                if(_dataBytes.Count == 0)
+                    return;
+
                 // Now that we know the total size of the byte array, we can update the struct size and store it in the constant field
                 StructType.ClassSize = _dataBytes.Count;
                 for (int i = 0; i < _dataBytes.Count; i++)


### PR DESCRIPTION
Calling Squeeze() on an assembly that do not contain any string literals corrupt the assembly.