### PR TITLE
Add KeepInternalApi Setting

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -808,8 +808,7 @@ namespace Obfuscar
             return false;
         }
 
-        public bool ShouldSkip(TypeKey type, InheritMap map, bool keepPublicApi, bool hidePrivateApi, bool markedOnly,
-            out string message)
+        public bool ShouldSkip(TypeKey type, InheritMap map, Settings settings, out string message)
         {
             var attribute = type.TypeDefinition.MarkedToRename();
             if (attribute != null)
@@ -818,7 +817,7 @@ namespace Obfuscar
                 return !attribute.Value;
             }
 
-            if (markedOnly)
+            if (settings.MarkedOnly)
             {
                 message = "MarkedOnly option in configuration";
                 return true;
@@ -857,15 +856,14 @@ namespace Obfuscar
             if (type.TypeDefinition.IsTypePublic())
             {
                 message = "KeepPublicApi option in configuration";
-                return keepPublicApi;
+                return settings.KeepPublicApi;
             }
 
             message = "HidePrivateApi option in configuration";
-            return !hidePrivateApi;
+            return !settings.HidePrivateApi;
         }
 
-        public bool ShouldSkip(MethodKey method, InheritMap map, bool keepPublicApi, bool hidePrivateApi,
-            bool markedOnly, out string message)
+        public bool ShouldSkip(MethodKey method, InheritMap map, Settings settings, out string message)
         {
             if (method.Method.IsRuntime)
             {
@@ -891,11 +889,10 @@ namespace Obfuscar
                 }
             }
 
-            return ShouldSkipParams(method, map, keepPublicApi, hidePrivateApi, markedOnly, out message);
+            return ShouldSkipParams(method, map, settings, out message);
         }
 
-        public bool ShouldSkipParams(MethodKey method, InheritMap map, bool keepPublicApi, bool hidePrivateApi,
-            bool markedOnly, out string message)
+        public bool ShouldSkipParams(MethodKey method, InheritMap map, Settings settings, out string message)
         {
             var attribute = method.Method.MarkedToRename();
             // skip runtime methods
@@ -912,7 +909,7 @@ namespace Obfuscar
                 return !parent.Value;
             }
 
-            if (markedOnly)
+            if (settings.MarkedOnly)
             {
                 message = "MarkedOnly option in configuration";
                 return true;
@@ -948,11 +945,11 @@ namespace Obfuscar
             ))
             {
                 message = "KeepPublicApi option in configuration";
-                return keepPublicApi;
+                return settings.KeepPublicApi;
             }
 
             message = "HidePrivateApi option in configuration";
-            return !hidePrivateApi;
+            return !settings.HidePrivateApi;
         }
 
         public bool ShouldSkipStringHiding(MethodKey method, InheritMap map, bool projectHideStrings)
@@ -976,8 +973,7 @@ namespace Obfuscar
             return !projectHideStrings;
         }
 
-        public bool ShouldSkip(FieldKey field, InheritMap map, bool keepPublicApi, bool hidePrivateApi, bool markedOnly,
-            out string message)
+        public bool ShouldSkip(FieldKey field, InheritMap map, Settings settings, out string message)
         {
             // skip runtime methods
             if ((field.Field.IsRuntimeSpecialName && field.Field.Name == "value__"))
@@ -1000,7 +996,7 @@ namespace Obfuscar
                 return !parent.Value;
             }
 
-            if (markedOnly)
+            if (settings.MarkedOnly)
             {
                 message = "MarkedOnly option in configuration";
                 return true;
@@ -1039,15 +1035,14 @@ namespace Obfuscar
             if (field.Field.IsPublic() && field.DeclaringType.IsTypePublic())
             {
                 message = "KeepPublicApi option in configuration";
-                return keepPublicApi;
+                return settings.KeepPublicApi;
             }
 
             message = "HidePrivateApi option in configuration";
-            return !hidePrivateApi;
+            return !settings.HidePrivateApi;
         }
 
-        public bool ShouldSkip(PropertyKey prop, InheritMap map, bool keepPublicApi, bool hidePrivateApi,
-            bool markedOnly, out string message)
+        public bool ShouldSkip(PropertyKey prop, InheritMap map, Settings settings, out string message)
         {
             if (prop.Property.IsRuntimeSpecialName)
             {
@@ -1069,7 +1064,7 @@ namespace Obfuscar
                 return !parent.Value;
             }
 
-            if (markedOnly)
+            if (settings.MarkedOnly)
             {
                 message = "MarkedOnly option in configuration";
                 return true;
@@ -1106,15 +1101,14 @@ namespace Obfuscar
             ))
             {
                 message = "KeepPublicApi option in configuration";
-                return keepPublicApi;
+                return settings.KeepPublicApi;
             }
 
             message = "HidePrivateApi option in configuration";
-            return !hidePrivateApi;
+            return !settings.HidePrivateApi;
         }
 
-        public bool ShouldSkip(EventKey evt, InheritMap map, bool keepPublicApi, bool hidePrivateApi, bool markedOnly,
-            out string message)
+        public bool ShouldSkip(EventKey evt, InheritMap map, Settings settings, out string message)
         {
             // skip runtime special events
             if (evt.Event.IsRuntimeSpecialName)
@@ -1138,7 +1132,7 @@ namespace Obfuscar
                 return !parent.Value;
             }
 
-            if (markedOnly)
+            if (settings.MarkedOnly)
             {
                 message = "MarkedOnly option in configuration";
                 return true;
@@ -1175,11 +1169,11 @@ namespace Obfuscar
             ))
             {
                 message = "KeepPublicApi option in configuration";
-                return keepPublicApi;
+                return settings.KeepPublicApi;
             }
 
             message = "HidePrivateApi option in configuration";
-            return !hidePrivateApi;
+            return !settings.HidePrivateApi;
         }
 
         /// <summary>

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -859,6 +859,12 @@ namespace Obfuscar
                 return settings.KeepPublicApi;
             }
 
+            if (type.TypeDefinition.IsTypeInternal())
+            {
+                message = "KeepInternalApi option in configuration";
+                return settings.KeepInternalApi;
+            }
+
             message = "HidePrivateApi option in configuration";
             return !settings.HidePrivateApi;
         }
@@ -946,6 +952,12 @@ namespace Obfuscar
             {
                 message = "KeepPublicApi option in configuration";
                 return settings.KeepPublicApi;
+            }
+
+            if (method.Method.IsInternal() || method.DeclaringType.IsTypeInternal())
+            {
+                message = "KeepInternalApi option in configuration";
+                return settings.KeepInternalApi;
             }
 
             message = "HidePrivateApi option in configuration";
@@ -1038,6 +1050,12 @@ namespace Obfuscar
                 return settings.KeepPublicApi;
             }
 
+            if (field.Field.IsInternal() || field.DeclaringType.IsTypeInternal())
+            {
+                message = "KeepInternalApi option in configuration";
+                return settings.KeepInternalApi;
+            }
+
             message = "HidePrivateApi option in configuration";
             return !settings.HidePrivateApi;
         }
@@ -1104,6 +1122,12 @@ namespace Obfuscar
                 return settings.KeepPublicApi;
             }
 
+            if (prop.Property.IsInternal() || prop.DeclaringType.IsTypeInternal())
+            {
+                message = "KeepInternalApi option in configuration";
+                return settings.KeepInternalApi;
+            }
+            
             message = "HidePrivateApi option in configuration";
             return !settings.HidePrivateApi;
         }
@@ -1170,6 +1194,12 @@ namespace Obfuscar
             {
                 message = "KeepPublicApi option in configuration";
                 return settings.KeepPublicApi;
+            }
+
+            if (evt.Event.IsInternal() || evt.DeclaringType.IsTypeInternal())
+            {
+                message = "KeepInternalApi option in configuration";
+                return settings.KeepInternalApi;
             }
 
             message = "HidePrivateApi option in configuration";

--- a/Obfuscar/Helpers/EventDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/EventDefinitionExtensions.cs
@@ -4,19 +4,33 @@ namespace Obfuscar.Helpers
 {
     internal static class EventDefinitionExtensions
     {
-        public static bool IsAddPublic(this EventDefinition eventDefinition)
+        public static bool IsPublic(this EventDefinition eventDefinition)
+        {
+            return eventDefinition.IsAddPublic() || eventDefinition.IsRemovePublic();
+        }
+        public static bool IsInternal(this EventDefinition eventDefinition)
+        {
+            return eventDefinition.IsAddInternal() || eventDefinition.IsRemoveInternal();
+        }
+        
+        private static bool IsAddPublic(this EventDefinition eventDefinition)
         {
             return eventDefinition.AddMethod.IsPublic();
         }
 
-        public static bool IsRemovePublic(this EventDefinition eventDefinition)
+        private static bool IsRemovePublic(this EventDefinition eventDefinition)
         {
             return eventDefinition.RemoveMethod.IsPublic();
         }
-
-        public static bool IsPublic(this EventDefinition eventDefinition)
+        
+        private static bool IsAddInternal(this EventDefinition eventDefinition)
         {
-            return eventDefinition.IsAddPublic() || eventDefinition.IsRemovePublic();
+            return eventDefinition.AddMethod.IsInternal();
+        }
+
+        private static bool IsRemoveInternal(this EventDefinition eventDefinition)
+        {
+            return eventDefinition.RemoveMethod.IsInternal();
         }
     }
 }

--- a/Obfuscar/Helpers/FieldDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/FieldDefinitionExtensions.cs
@@ -8,5 +8,10 @@ namespace Obfuscar.Helpers
         {
             return field != null && (field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly);
         }
+        
+        public static bool IsInternal(this FieldDefinition field)
+        {
+            return field != null && field.IsAssembly;
+        }
     }
 }

--- a/Obfuscar/Helpers/MethodDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/MethodDefinitionExtensions.cs
@@ -8,5 +8,10 @@ namespace Obfuscar.Helpers
         {
             return method != null && (method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly);
         }
+        
+        public static bool IsInternal(this MethodDefinition method)
+        {
+            return method != null && method.IsAssembly;
+        }
     }
 }

--- a/Obfuscar/Helpers/PropertyDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/PropertyDefinitionExtensions.cs
@@ -4,19 +4,34 @@ namespace Obfuscar.Helpers
 {
     internal static class PropertyDefinitionExtensions
     {
-        public static bool IsGetterPublic(this PropertyDefinition propertyDefinition)
+        public static bool IsPublic(this PropertyDefinition propertyDefinition)
+        {
+            return propertyDefinition.IsGetterPublic() || propertyDefinition.IsSetterPublic();
+        }
+
+        public static bool IsInternal(this PropertyDefinition propertyDefinition)
+        {
+            return propertyDefinition.IsGetterInternal() || propertyDefinition.IsSetterInternal();
+        }
+        
+        private static bool IsGetterPublic(this PropertyDefinition propertyDefinition)
         {
             return propertyDefinition.GetMethod.IsPublic();
         }
 
-        public static bool IsSetterPublic(this PropertyDefinition propertyDefinition)
+        private static bool IsSetterPublic(this PropertyDefinition propertyDefinition)
         {
             return propertyDefinition.SetMethod.IsPublic();
         }
-
-        public static bool IsPublic(this PropertyDefinition propertyDefinition)
+        
+        private static bool IsGetterInternal(this PropertyDefinition propertyDefinition)
         {
-            return propertyDefinition.IsGetterPublic() || propertyDefinition.IsSetterPublic();
+            return propertyDefinition.GetMethod.IsInternal();
+        }
+
+        private static bool IsSetterInternal(this PropertyDefinition propertyDefinition)
+        {
+            return propertyDefinition.SetMethod.IsInternal();
         }
     }
 }

--- a/Obfuscar/Helpers/TypeDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/TypeDefinitionExtensions.cs
@@ -17,6 +17,16 @@ namespace Obfuscar.Helpers
 
             return false;
         }
+        
+        public static bool IsTypeInternal(this TypeDefinition type)
+        {
+            // A non-nested, non-public type can only be internal,
+            // as private types would not be accessible and thus don't compile
+            if (!type.IsNested)
+                return type.IsNotPublic;
+            
+            return type.IsNestedAssembly || type.IsNestedFamilyOrAssembly;
+        }
 
         private static CacheItemPolicy policy = new CacheItemPolicy {SlidingExpiration = TimeSpan.FromMinutes(5)};
 

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -429,9 +429,7 @@ namespace Obfuscar
 
             // skip filtered fields
             string skip;
-            if (info.ShouldSkip(fieldKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkip(fieldKey, Project.InheritMap, Project.Settings, out skip))
             {
                 Mapping.UpdateField(fieldKey, ObfuscationStatus.Skipped, skip);
                 nameGroup.Add(fieldKey.Name);
@@ -495,8 +493,7 @@ namespace Obfuscar
 
                     string skip;
                     // rename the class parameters
-                    if (info.ShouldSkip(new TypeKey(type), Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                    if (info.ShouldSkip(new TypeKey(type), Project.InheritMap, Project.Settings, out skip))
                         continue;
 
                     int index = 0;
@@ -510,8 +507,7 @@ namespace Obfuscar
         {
             MethodKey methodkey = new MethodKey(method);
             string skip;
-            if (info.ShouldSkipParams(methodkey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkipParams(methodkey, Project.InheritMap, Project.Settings, out skip))
                 return;
 
             foreach (ParameterDefinition param in method.Parameters)
@@ -561,8 +557,7 @@ namespace Obfuscar
                     string fullName = type.FullName;
 
                     string skip;
-                    if (info.ShouldSkip(unrenamedTypeKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                    if (info.ShouldSkip(unrenamedTypeKey, Project.InheritMap, Project.Settings, out skip))
                     {
                         Mapping.UpdateType(oldTypeKey, ObfuscationStatus.Skipped, skip);
 
@@ -884,9 +879,7 @@ namespace Obfuscar
 
             string skip;
             // skip filtered props
-            if (info.ShouldSkip(propKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkip(propKey, Project.InheritMap, Project.Settings, out skip))
             {
                 m.Update(ObfuscationStatus.Skipped, skip);
 
@@ -998,9 +991,7 @@ namespace Obfuscar
 
             string skip;
             // skip filtered events
-            if (info.ShouldSkip(evtKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkip(evtKey, Project.InheritMap, Project.Settings, out skip))
             {
                 m.Update(ObfuscationStatus.Skipped, skip);
 
@@ -1123,8 +1114,7 @@ namespace Obfuscar
 
             // skip filtered methods
             string skiprename;
-            var toDo = info.ShouldSkip(methodKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skiprename);
+            var toDo = info.ShouldSkip(methodKey, Project.InheritMap, Project.Settings, out skiprename);
             if (!toDo)
                 skiprename = null;
             // update status for skipped non-virtual methods immediately...status for

--- a/Obfuscar/Settings.cs
+++ b/Obfuscar/Settings.cs
@@ -43,6 +43,7 @@ namespace Obfuscar
             RenameEvents = XmlConvert.ToBoolean(vars.GetValue("RenameEvents", "true"));
             KeepPublicApi = XmlConvert.ToBoolean(vars.GetValue("KeepPublicApi", "true"));
             HidePrivateApi = XmlConvert.ToBoolean(vars.GetValue("HidePrivateApi", "true"));
+            KeepInternalApi = !HidePrivateApi || XmlConvert.ToBoolean(vars.GetValue("KeepInternalApi", "false"));
             ReuseNames = XmlConvert.ToBoolean(vars.GetValue("ReuseNames", "true"));
             UseUnicodeNames = XmlConvert.ToBoolean(vars.GetValue("UseUnicodeNames", "false"));
             UseKoreanNames = XmlConvert.ToBoolean(vars.GetValue("UseKoreanNames", "false"));
@@ -75,6 +76,8 @@ namespace Obfuscar
         public bool KeepPublicApi { get; }
 
         public bool HidePrivateApi { get; }
+        
+        public bool KeepInternalApi { get; }
 
         public bool ReuseNames { get; }
 

--- a/Tests/AutoSkipTypeTests.cs
+++ b/Tests/AutoSkipTypeTests.cs
@@ -1,6 +1,5 @@
 ﻿using Mono.Cecil;
 using Obfuscar;
-using System;
 using System.IO;
 using Xunit;
 
@@ -59,7 +58,7 @@ namespace ObfuscarTests
 
             Assert.True(classA.Status == ObfuscationStatus.Renamed, "Public class is not obfuscated");
             Assert.True(classAMethod1.Status == ObfuscationStatus.Skipped, "private method is obfuscated.");
-            Assert.True(classAMethod2.Status == ObfuscationStatus.Renamed, "pubilc method is not obfuscated.");
+            Assert.True(classAMethod2.Status == ObfuscationStatus.Renamed, "public method is not obfuscated.");
         }
 
         [Fact]
@@ -124,7 +123,7 @@ namespace ObfuscarTests
             var classA = map.GetClass(new TypeKey(classAType));
             Assert.True(classA.Status == ObfuscationStatus.Renamed, "Public class should have been obfuscated");
             Assert.True(classAMethod1.Status == ObfuscationStatus.Renamed, "private method is not obfuscated.");
-            Assert.True(classAMethod2.Status == ObfuscationStatus.Renamed, "pubilc method is not obfuscated.");
+            Assert.True(classAMethod2.Status == ObfuscationStatus.Renamed, "public method is not obfuscated.");
 
             var protectedMethod = FindByName(classAType, "ProtectedMethod");
             var protectedAfter = map.GetMethod(new MethodKey(protectedMethod));
@@ -164,12 +163,124 @@ namespace ObfuscarTests
             var classA = map.GetClass(new TypeKey(classAType));
             Assert.True(classA.Status == ObfuscationStatus.Skipped, "Public class shouldn't have been obfuscated");
             Assert.True(classAMethod1.Status == ObfuscationStatus.Renamed, "private method is not obfuscated.");
-            Assert.True(classAMethod2.Status == ObfuscationStatus.Skipped, "pubilc method is obfuscated.");
+            Assert.True(classAMethod2.Status == ObfuscationStatus.Skipped, "public method is obfuscated.");
             Assert.True(classAMethod3.Status == ObfuscationStatus.Skipped, "internal protected method is obfuscated.");
 
             var protectedMethod = FindByName(classAType, "ProtectedMethod");
             var protectedAfter = map.GetMethod(new MethodKey(protectedMethod));
             Assert.True(protectedAfter.Status == ObfuscationStatus.Skipped, "protected method is obfuscated.");
+        }
+
+        [Fact]
+        public void CheckKeepInternalApiFalse()
+        {
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepPublicApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='false' />" +
+                @"<Module file='$(InPath){2}AssemblyWithTypes.dll'>" +
+                @"</Module>" +
+                @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar);
+
+            var obfuscator = TestHelper.BuildAndObfuscate("AssemblyWithTypes", string.Empty, xml);
+            var map = obfuscator.Mapping;
+
+            string assmName = "AssemblyWithTypes.dll";
+
+            AssemblyDefinition inAssmDef = AssemblyDefinition.ReadAssembly(
+                Path.Combine(TestHelper.InputPath, assmName));
+
+            TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
+            MethodDefinition privateMethodDefinition = FindByName(classAType, "PrivateMethod");
+            MethodDefinition internalMethodDefinition = FindByName(classAType, "InternalMethod");
+            MethodDefinition internalProtectedMethodDefinition = FindByName(classAType, "InternalProtectedMethod");
+            MethodDefinition protectedInternalMethodDefinition = FindByName(classAType, "ProtectedInternalMethod");
+            MethodDefinition protectedMethodDefinition = FindByName(classAType, "ProtectedMethod");
+            MethodDefinition publicMethodDefinition = FindByName(classAType, "PublicMethod");
+
+            ObfuscatedThing privateMethod = map.GetMethod(new MethodKey(privateMethodDefinition));
+            ObfuscatedThing internalMethod = map.GetMethod(new MethodKey(internalMethodDefinition));
+            ObfuscatedThing internalProtectedMethod = map.GetMethod(new MethodKey(internalProtectedMethodDefinition));
+            ObfuscatedThing protectedInternalMethod = map.GetMethod(new MethodKey(protectedInternalMethodDefinition));
+            ObfuscatedThing protectedMethod = map.GetMethod(new MethodKey(protectedMethodDefinition));
+            ObfuscatedThing publicMethod = map.GetMethod(new MethodKey(publicMethodDefinition));
+
+            var classA = map.GetClass(new TypeKey(classAType));
+            Assert.True(classA.Status == ObfuscationStatus.Skipped, "Public class shouldn't have been obfuscated");
+            Assert.True(privateMethod.Status == ObfuscationStatus.Renamed, "private method is not obfuscated.");
+            Assert.True(internalMethod.Status == ObfuscationStatus.Renamed, "internal method is not obfuscated.");
+            Assert.True(internalProtectedMethod.Status == ObfuscationStatus.Skipped, "internal protected method is obfuscated.");
+            Assert.True(protectedInternalMethod.Status == ObfuscationStatus.Skipped, "protected internal method is obfuscated.");
+            Assert.True(protectedMethod.Status == ObfuscationStatus.Skipped, "protected method is obfuscated.");
+            Assert.True(publicMethod.Status == ObfuscationStatus.Skipped, "public method is obfuscated.");
+        }
+
+        [Fact]
+        public void CheckKeepInternalApiTrue()
+        {
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepPublicApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='true' />" +
+                @"<Module file='$(InPath){2}AssemblyWithTypes.dll'>" +
+                @"</Module>" +
+                @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar);
+
+            Obfuscar.Obfuscator obfuscator = TestHelper.BuildAndObfuscate("AssemblyWithTypes", string.Empty, xml);
+            var map = obfuscator.Mapping;
+
+            string assmName = "AssemblyWithTypes.dll";
+
+            AssemblyDefinition inAssmDef = AssemblyDefinition.ReadAssembly(
+                Path.Combine(TestHelper.InputPath, assmName));
+
+            TypeDefinition publicClassType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
+            MethodDefinition privateMethodDefinition = FindByName(publicClassType, "PrivateMethod");
+            MethodDefinition internalMethodDefinition = FindByName(publicClassType, "InternalMethod");
+            MethodDefinition internalProtectedMethodDefinition = FindByName(publicClassType, "InternalProtectedMethod");
+            MethodDefinition protectedInternalMethodDefinition = FindByName(publicClassType, "ProtectedInternalMethod");
+            MethodDefinition protectedMethodDefinition = FindByName(publicClassType, "ProtectedMethod");
+            MethodDefinition publicMethodDefinition = FindByName(publicClassType, "PublicMethod");
+
+            ObfuscatedThing privateMethod = map.GetMethod(new MethodKey(privateMethodDefinition));
+            ObfuscatedThing internalMethod = map.GetMethod(new MethodKey(internalMethodDefinition));
+            ObfuscatedThing internalProtectedMethod = map.GetMethod(new MethodKey(internalProtectedMethodDefinition));
+            ObfuscatedThing protectedInternalMethod = map.GetMethod(new MethodKey(protectedInternalMethodDefinition));
+            ObfuscatedThing protectedMethod = map.GetMethod(new MethodKey(protectedMethodDefinition));
+            ObfuscatedThing publicMethod = map.GetMethod(new MethodKey(publicMethodDefinition));
+            
+            TypeDefinition publicStaticClassType = inAssmDef.MainModule.GetType("TestClasses.PublicStaticClass");
+            MethodDefinition internalStaticMethodDefinition = FindByName(publicStaticClassType, "InternalStaticMethod");
+            ObfuscatedThing internalStaticMethod = map.GetMethod(new MethodKey(internalStaticMethodDefinition));
+            
+            TypeDefinition internalStaticClassType = inAssmDef.MainModule.GetType("TestClasses.InternalStaticClass");
+            MethodDefinition publicStaticMethodDefinition = FindByName(internalStaticClassType, "PublicStaticMethod");
+            ObfuscatedThing publicStaticMethod = map.GetMethod(new MethodKey(publicStaticMethodDefinition));
+
+            var publicClass = map.GetClass(new TypeKey(publicClassType));
+            Assert.True(publicClass.Status == ObfuscationStatus.Skipped, "Public class shouldn't have been obfuscated");
+            Assert.True(privateMethod.Status == ObfuscationStatus.Renamed, "private method is not obfuscated.");
+            Assert.True(internalMethod.Status == ObfuscationStatus.Skipped, "internal method is obfuscated.");
+            Assert.True(internalProtectedMethod.Status == ObfuscationStatus.Skipped, "internal protected method is obfuscated.");
+            Assert.True(protectedInternalMethod.Status == ObfuscationStatus.Skipped, "protected internal method is obfuscated.");
+            Assert.True(protectedMethod.Status == ObfuscationStatus.Skipped, "protected method is obfuscated.");
+            Assert.True(publicMethod.Status == ObfuscationStatus.Skipped, "public method is obfuscated.");
+            
+            var publicStaticClass = map.GetClass(new TypeKey(publicStaticClassType));
+            Assert.True(publicStaticClass.Status == ObfuscationStatus.Skipped, "Public static class shouldn't have been obfuscated");
+            Assert.True(internalStaticMethod.Status == ObfuscationStatus.Skipped, "internal static method is obfuscated.");
+            
+            var internalStaticClass = map.GetClass(new TypeKey(internalStaticClassType));
+            Assert.True(internalStaticClass.Status == ObfuscationStatus.Skipped, "Internal static class shouldn't have been obfuscated");
+            Assert.True(publicStaticMethod.Status == ObfuscationStatus.Skipped, "public static method is obfuscated.");
         }
 
         [Fact]

--- a/Tests/Input/AssemblyWithNestedTypes2.cs
+++ b/Tests/Input/AssemblyWithNestedTypes2.cs
@@ -30,12 +30,15 @@ namespace TestClasses
 {
 	public class ClassA
 	{
-		internal class NestedClassA
+		private class NestedClassA
 		{
 		}
-		public class NestedClassB
+		internal class NestedClassB
 		{
-			public class NestedClassC
+		}
+		public class NestedClassC
+		{
+			public class NestedClassD
 			{				
 			}
 		}

--- a/Tests/Input/AssemblyWithTypes.cs
+++ b/Tests/Input/AssemblyWithTypes.cs
@@ -52,6 +52,9 @@ namespace TestClasses
 		public void PublicMethod()
 		{ }
 
+		internal void InternalMethod()
+		{ }
+
 		protected void ProtectedMethod()
 		{ }
 
@@ -59,6 +62,18 @@ namespace TestClasses
 		{ }
 
 		protected internal void ProtectedInternalMethod()
+		{ }
+	}
+
+	public static class PublicStaticClass
+	{
+		internal static void InternalStaticMethod()
+		{ }
+	}
+
+	internal static class InternalStaticClass
+	{
+		public static void PublicStaticMethod()
 		{ }
 	}
 }
@@ -71,6 +86,10 @@ namespace TestClasses1
 		{ }
 
 		public class PublicNestedClass
+		{
+		}
+
+		internal class InternalNestedClass
 		{
 		}
 	}

--- a/Tests/SkipEnumTests.cs
+++ b/Tests/SkipEnumTests.cs
@@ -89,6 +89,34 @@ namespace ObfuscarTests
         }
 
         [Fact]
+        public void CheckKeepInternalEnums()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='true' />" +
+                @"<Module file='$(InPath){2}AssemblyWithEnums.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            TestHelper.BuildAndObfuscate("AssemblyWithEnums", string.Empty, xml);
+
+            string[] expected = new string[]
+            {
+                "Value1",
+                "Value2",
+                "ValueA"
+            };
+
+            string[] notExpected = new string[0];
+
+            CheckEnums(Path.Combine(outputPath, "AssemblyWithEnums.dll"), 2, expected, notExpected);
+        }
+
+        [Fact]
         public void CheckSkipEnumsByName()
         {
             string outputPath = TestHelper.OutputPath;

--- a/Tests/SkipEventTests.cs
+++ b/Tests/SkipEventTests.cs
@@ -128,6 +128,34 @@ namespace ObfuscarTests
         }
 
         [Fact]
+        public void CheckKeepInternalEvents()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='true' />" +
+                @"<Module file='$(InPath){2}AssemblyWithEvents.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            TestHelper.BuildAndObfuscate("AssemblyWithEvents", string.Empty, xml);
+
+            string[] expected = new string[]
+            {
+                "Event1",
+                "Event2",
+                "EventA"
+            };
+
+            string[] notExpected = new string[0];
+
+            CheckEvents(Path.Combine(outputPath, "AssemblyWithEvents.dll"), 1, expected, notExpected);
+        }
+
+        [Fact]
         public void CheckSkipEventsByName()
         {
             string outputPath = TestHelper.OutputPath;

--- a/Tests/SkipNestedTypeTests.cs
+++ b/Tests/SkipNestedTypeTests.cs
@@ -88,8 +88,45 @@ namespace ObfuscarTests
             HashSet<string> typesToFind = new HashSet<string>();
             typesToFind.Add("TestClasses.ClassA");
             typesToFind.Add("TestClasses.ClassA/A");
+            typesToFind.Add("TestClasses.ClassA/a");
+            typesToFind.Add("TestClasses.ClassA/NestedClassC");
+            typesToFind.Add("TestClasses.ClassA/NestedClassC/NestedClassD");
+
+            AssemblyHelper.CheckAssembly(Path.Combine(outputPath, "AssemblyWithNestedTypes2.dll"), 1,
+                delegate { return true; },
+                delegate(TypeDefinition typeDef)
+                {
+                    Assert.True(typesToFind.Contains(typeDef.ToString()),
+                        string.Format("Type {0} not expected.", typeDef.ToString()));
+                    typesToFind.Remove(typeDef.ToString());
+                });
+            Assert.True(typesToFind.Count == 0, "Not all types found.");
+        }
+
+        [Fact]
+        public void CheckKeepInternal()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='true' />" +
+                @"<Var name='KeepPublicApi' value='true' />" +
+                @"<Module file='$(InPath){2}AssemblyWithNestedTypes2.dll'>" +
+                @"</Module>" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            TestHelper.BuildAndObfuscate("AssemblyWithNestedTypes2", string.Empty, xml);
+
+            HashSet<string> typesToFind = new HashSet<string>();
+            typesToFind.Add("TestClasses.ClassA");
+            typesToFind.Add("TestClasses.ClassA/A");
             typesToFind.Add("TestClasses.ClassA/NestedClassB");
-            typesToFind.Add("TestClasses.ClassA/NestedClassB/NestedClassC");
+            typesToFind.Add("TestClasses.ClassA/NestedClassC");
+            typesToFind.Add("TestClasses.ClassA/NestedClassC/NestedClassD");
 
             AssemblyHelper.CheckAssembly(Path.Combine(outputPath, "AssemblyWithNestedTypes2.dll"), 1,
                 delegate { return true; },

--- a/Tests/SkipPropertyTests.cs
+++ b/Tests/SkipPropertyTests.cs
@@ -101,6 +101,34 @@ namespace ObfuscarTests
         }
 
         [Fact]
+        public void CheckKeepInternalProperties()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Var name='KeepInternalApi' value='true' />" +
+                @"<Module file='$(InPath){2}AssemblyWithProperties.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            TestHelper.BuildAndObfuscate("AssemblyWithProperties", string.Empty, xml);
+
+            string[] expected = new string[]
+            {
+                "Property1",
+                "Property2",
+                "PropertyA"
+            };
+
+            string[] notExpected = new string[0];
+
+            CheckProperties(Path.Combine(outputPath, "AssemblyWithProperties.dll"), 1, expected, notExpected);
+        }
+
+        [Fact]
         public void CheckSkipPropertyByName()
         {
             string outputPath = TestHelper.OutputPath;


### PR DESCRIPTION
Sometimes there's a need for one assembly to access `internal` symbols of another assembly. As Obfuscar also obfuscates `internal` symbols with the `HidePrivateApi`, the calls from the external assembly will fail with `MethodNotFoundException`.

Currently there's no simple way to exclude all `internal` marked symbols. You have to either manually exclude the namespace, type, method, etc. or you can use `[Obfuscation(Exclude = true)]` in code, either way it's manual work and thus also prone to error.

Are there any ways to keep `internal` symbols or ensure `internal` symbols are translated in other assemblies that I've missed?

Similar to `HidePrivateApi` and `KeepPublicApi`, I'd propose to add `KeepInternalApi`.

- When `KeepInternalApi` is set to `true` the `internal` symbols are excluded from `HidePrivateApi` processing.
- By default `KeepInternalApi` is set to `false` to retain backwards compatibility.
- When `HidePrivateApi` is set to `false`, `KeepInternalApi` is overwritten internally with `true` to prevent obfuscation of "private-ish" symbols.

## Example

```xml
<?xml version="1.0"?>
<Obfuscator>
    <Var name="InPath" value="./" />
    <Var name="OutPath" value="obfuscated" />
    <Var name="HidePrivateApi" value="true" />
    <Var name="KeepPublicApi" value="true" />
    <Var name="KeepInternalApi" value="false" />
    <Module file="$(InPath)TestAssembly.dll">
    </Module>
</Obfuscator>
```