### PR TITLE
Check for empty string and centralize variable names

### DIFF
--- a/Obfuscar/AssemblyCache.cs
+++ b/Obfuscar/AssemblyCache.cs
@@ -67,7 +67,7 @@ namespace Obfuscar
             }
             catch (FileNotFoundException)
             {
-                throw new ObfuscarException("Unable to resolve dependency:  " + name.Name);
+                throw new ObfuscarException("Unable to resolve dependency: " + name.Name);
             }
 
             string fullName = type.GetFullName();

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -711,7 +711,7 @@ namespace Obfuscar
             }
             catch (System.IO.IOException e)
             {
-                throw new ObfuscarException("Unable to find assembly:  " + filename, e);
+                throw new ObfuscarException("Unable to find assembly: " + filename, e);
             }
         }
 

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -85,7 +85,7 @@ namespace Obfuscar
             }
             catch (IOException e)
             {
-                throw new ObfuscarException("Unable to read specified project file:  " + projfile, e);
+                throw new ObfuscarException("Unable to read specified project file: " + projfile, e);
             }
             catch (System.Xml.XmlException e)
             {

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -392,7 +392,7 @@ namespace Obfuscar
                 }
                 catch (IOException e)
                 {
-                    throw new ObfuscarException("Could not create path specified by OutPath:  " + Settings.OutPath, e);
+                    throw new ObfuscarException("Could not create path specified by OutPath: " + Settings.OutPath, e);
                 }
             }
         }

--- a/Obfuscar/Settings.cs
+++ b/Obfuscar/Settings.cs
@@ -31,29 +31,54 @@ namespace Obfuscar
 {
     class Settings
     {
+        internal const string VariableAnalyzeXaml = "AnalyzeXaml";
+        internal const string VariableCustomChars = "CustomChars";
+        internal const string VariableExtraFrameworkFolders = "ExtraFrameworkFolders";
+        internal const string VariableHidePrivateApi = "HidePrivateApi";
+        internal const string VariableHideStrings = "HideStrings";
+        internal const string VariableInPath = "InPath";
+        internal const string VariableKeepPublicApi = "KeepPublicApi";
+        internal const string VariableKeyContainer = "KeyContainer";
+        internal const string VariableKeyFile = "KeyFile";
+        internal const string VariableLogFile = "LogFile";
+        internal const string VariableMarkedOnly = "MarkedOnly";
+        internal const string VariableOptimizeMethods = "OptimizeMethods";
+        internal const string VariableOutPath = "OutPath";
+        internal const string VariableRegenerateDebugInfo = "RegenerateDebugInfo";
+        internal const string VariableRenameEvents = "RenameEvents";
+        internal const string VariableRenameFields = "RenameFields";
+        internal const string VariableRenameProperties = "RenameProperties";
+        internal const string VariableReuseNames = "ReuseNames";
+        internal const string VariableSuppressIldasm = "SuppressIldasm";
+        internal const string VariableUseKoreanNames = "UseKoreanNames";
+        internal const string VariableUseUnicodeNames = "UseUnicodeNames";
+        internal const string VariableXmlMapping = "XmlMapping";
+
+        internal const string SpecialVariableProjectFileDirectory = "ProjectFileDirectory";
+
         public Settings(Variables vars)
         {
-            InPath = Environment.ExpandEnvironmentVariables(vars.GetValue("InPath", "."));
-            OutPath = Environment.ExpandEnvironmentVariables(vars.GetValue("OutPath", "."));
-            LogFilePath = Environment.ExpandEnvironmentVariables(vars.GetValue("LogFile", ""));
-            MarkedOnly = XmlConvert.ToBoolean(vars.GetValue("MarkedOnly", "false"));
+            InPath = Environment.ExpandEnvironmentVariables(vars.GetValue(VariableInPath, "."));
+            OutPath = Environment.ExpandEnvironmentVariables(vars.GetValue(VariableOutPath, "."));
+            LogFilePath = Environment.ExpandEnvironmentVariables(vars.GetValue(VariableLogFile, ""));
+            MarkedOnly = XmlConvert.ToBoolean(vars.GetValue(VariableMarkedOnly, "false"));
 
-            RenameFields = XmlConvert.ToBoolean(vars.GetValue("RenameFields", "true"));
-            RenameProperties = XmlConvert.ToBoolean(vars.GetValue("RenameProperties", "true"));
-            RenameEvents = XmlConvert.ToBoolean(vars.GetValue("RenameEvents", "true"));
-            KeepPublicApi = XmlConvert.ToBoolean(vars.GetValue("KeepPublicApi", "true"));
-            HidePrivateApi = XmlConvert.ToBoolean(vars.GetValue("HidePrivateApi", "true"));
-            ReuseNames = XmlConvert.ToBoolean(vars.GetValue("ReuseNames", "true"));
-            UseUnicodeNames = XmlConvert.ToBoolean(vars.GetValue("UseUnicodeNames", "false"));
-            UseKoreanNames = XmlConvert.ToBoolean(vars.GetValue("UseKoreanNames", "false"));
-            HideStrings = XmlConvert.ToBoolean(vars.GetValue("HideStrings", "true"));
-            Optimize = XmlConvert.ToBoolean(vars.GetValue("OptimizeMethods", "true"));
-            SuppressIldasm = XmlConvert.ToBoolean(vars.GetValue("SuppressIldasm", "true"));
+            RenameFields = XmlConvert.ToBoolean(vars.GetValue(VariableRenameFields, "true"));
+            RenameProperties = XmlConvert.ToBoolean(vars.GetValue(VariableRenameProperties, "true"));
+            RenameEvents = XmlConvert.ToBoolean(vars.GetValue(VariableRenameEvents, "true"));
+            KeepPublicApi = XmlConvert.ToBoolean(vars.GetValue(VariableKeepPublicApi, "true"));
+            HidePrivateApi = XmlConvert.ToBoolean(vars.GetValue(VariableHidePrivateApi, "true"));
+            ReuseNames = XmlConvert.ToBoolean(vars.GetValue(VariableReuseNames, "true"));
+            UseUnicodeNames = XmlConvert.ToBoolean(vars.GetValue(VariableUseUnicodeNames, "false"));
+            UseKoreanNames = XmlConvert.ToBoolean(vars.GetValue(VariableUseKoreanNames, "false"));
+            HideStrings = XmlConvert.ToBoolean(vars.GetValue(VariableHideStrings, "true"));
+            Optimize = XmlConvert.ToBoolean(vars.GetValue(VariableOptimizeMethods, "true"));
+            SuppressIldasm = XmlConvert.ToBoolean(vars.GetValue(VariableSuppressIldasm, "true"));
 
-            XmlMapping = XmlConvert.ToBoolean(vars.GetValue("XmlMapping", "false"));
-            RegenerateDebugInfo = XmlConvert.ToBoolean(vars.GetValue("RegenerateDebugInfo", "false"));
-            AnalyzeXaml = XmlConvert.ToBoolean(vars.GetValue("AnalyzeXaml", "false"));
-            CustomChars = vars.GetValue("CustomChars", "");
+            XmlMapping = XmlConvert.ToBoolean(vars.GetValue(VariableXmlMapping, "false"));
+            RegenerateDebugInfo = XmlConvert.ToBoolean(vars.GetValue(VariableRegenerateDebugInfo, "false"));
+            AnalyzeXaml = XmlConvert.ToBoolean(vars.GetValue(VariableAnalyzeXaml, "false"));
+            CustomChars = vars.GetValue(VariableCustomChars, "");
         }
 
         public bool RegenerateDebugInfo { get; }

--- a/Obfuscar/Variables.cs
+++ b/Obfuscar/Variables.cs
@@ -74,7 +74,7 @@ namespace Obfuscar
                 if (vars.TryGetValue(variable, out replacement))
                     formatted.Append(this.Replace(replacement));
                 else
-                    throw new ObfuscarException("Unable to replace variable:  " + variable);
+                    throw new ObfuscarException("Unable to replace variable: " + variable);
 
                 lastMatch = m.Index + m.Length;
             }


### PR DESCRIPTION
When debugging the intended use of KeyContainer and whether it is possible to use a hardware token with it, I have made some changes to make the code more readable, plus avoid potential problem when the variables would be string.empty instead of null.