### PR TITLE
Fix MemberDefinitionExtensions.MarkedToRename to return null when ObfuscationAttribute.ApplyToMembers is false

### DIFF
--- a/Obfuscar/Helpers/MemberDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/MemberDefinitionExtensions.cs
@@ -23,7 +23,7 @@ namespace Obfuscar.Helpers
                     var rename = !(bool)(Helper.GetAttributePropertyByName(attr, "Exclude") ?? true);
 
                     if (fromMember && !applyToMembers)
-                        return !rename;
+                        return null;
 
                     return rename;
                 }


### PR DESCRIPTION
As described in issue #568