### PR TITLE
missing "System.Reflection.Metadata" package reference (closes #593)

### DIFF
--- a/src/Console/Obfuscar.Console.csproj
+++ b/src/Console/Obfuscar.Console.csproj
@@ -21,5 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Reflection.Metadata">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding package reference fixes bug #593 in Obfuscar.Console