### PR TITLE
introduced CustomAttributesToPreservePropertyNames settings (closes #609)

### DIFF
--- a/src/Obfuscar/Obfuscator.cs
+++ b/src/Obfuscar/Obfuscator.cs
@@ -1153,6 +1153,38 @@ namespace Obfuscar
                         m.Update(ObfuscationStatus.Renamed, "dropped");
                         type.Properties.Remove(prop);
                     }
+
+                    RenamePropertyUsageInCustomAttributeArguments(type, typeKey);
+                }
+            }
+        }
+
+        private void RenamePropertyUsageInCustomAttributeArguments(TypeDefinition type, TypeKey typeKey)
+        {
+            if (Project.Settings.CustomAttributesToPreservePropertyNames.Length > 0)
+            {
+                foreach (PropertyDefinition prop in type.Properties)
+                {
+                    var attributesToUpdate = prop.CustomAttributeTypeFullNames.Intersect(Project.Settings.CustomAttributesToPreservePropertyNames);
+                    if (attributesToUpdate.Any())
+                    {
+                        foreach (var attributeToUpdate in attributesToUpdate)
+                        {
+                            foreach (var customAttribute in prop.CustomAttributes.Where(ca => ca.AttributeType.FullName == attributeToUpdate))
+                            {
+                                foreach (var constructorArgument in customAttribute.ConstructorArguments)
+                                {
+                                    foreach (var otherObfuscatedProp in Mapping.GetClass(typeKey).Properties.Where(x => x.Value.Status == ObfuscationStatus.Renamed))
+                                    {
+                                        if (string.Equals(otherObfuscatedProp.Key.Name, constructorArgument.Value))
+                                        {
+                                            constructorArgument.Value = otherObfuscatedProp.Value.StatusText;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/Obfuscar/Settings.cs
+++ b/src/Obfuscar/Settings.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml;
 
 namespace Obfuscar
@@ -79,6 +80,9 @@ namespace Obfuscar
             SkipGenerated = XmlConvert.ToBoolean(vars.GetValue("SkipGenerated", "false"));
             SkipSpecialName = XmlConvert.ToBoolean(vars.GetValue("SkipSpecialName", "false"));
             CustomChars = vars.GetValue("CustomChars", "");
+            
+            CustomAttributesToPreservePropertyNames = vars.GetValue("CustomAttributesToPreservePropertyNames", "")
+                .Split(';').Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)).ToArray();
         }
 
         public bool RegenerateDebugInfo { get; }
@@ -124,5 +128,7 @@ namespace Obfuscar
         public bool SkipSpecialName { get; }
 
         public string CustomChars { get; }
+        
+        public string[] CustomAttributesToPreservePropertyNames { get; set; }
     }
 }

--- a/src/Tests/Input/PreserveAttributeArgumentForReflectionTest.cs
+++ b/src/Tests/Input/PreserveAttributeArgumentForReflectionTest.cs
@@ -1,0 +1,38 @@
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PreserveAttributeArgumentForReflectionTest
+{	
+	public class ClassA
+	{
+        [System.ComponentModel.DisplayName("Enable Other properties")]
+        public bool FirstProperty => false;
+
+
+        [System.ComponentModel.DisplayName("Second Property")]
+        [VisibleByAttribute(nameof(FirstProperty))]
+        public string SecondProperty { get; set; }
+    }
+
+    [System.Reflection.Obfuscation]
+    [AttributeUsage(AttributeTargets.Property)]
+    public class VisibleByAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisibleByAttribute" /> class.
+        /// </summary>
+        /// <param name="propertyName">Name of the property that determines the visibility of the attributed property.</param>
+        public VisibleByAttribute(string propertyName)
+        {
+            this.PropertyName = propertyName;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the property.
+        /// </summary>
+        /// <value>The name of the property.</value>
+        public string PropertyName { get; set; }
+    }
+}

--- a/src/Tests/ObfuscarTests.csproj
+++ b/src/Tests/ObfuscarTests.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="PreserveAttributeArgumentForReflectionTests.cs" />
     <Compile Include="GenericMethodImplementationNamingTests.cs" />
     <Compile Include="ImportNestedTypeUsingStaticOuterClassTest.cs" />
     <Compile Include="GlobalUsings.Legacy.cs" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Tests/PreserveAttributeArgumentForReflectionTests.cs
+++ b/src/Tests/PreserveAttributeArgumentForReflectionTests.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ObfuscarTests
+{
+    public class PreserveAttributeArgumentForReflectionTests
+    {
+        const string SampleAttributeFullName = "PreserveAttributeArgumentForReflectionTest.VisibleByAttribute";
+
+        public string BuildAndObfuscateAssemblies()
+        {
+            var output = TestHelper.OutputPath;
+            var name = "PreserveAttributeArgumentForReflectionTest";
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='KeepPublicApi' value='false' />" +
+                string.Format("<Var name='CustomAttributesToPreservePropertyNames' value=' {0};\r\n{1};\r{2}' />",
+                    SampleAttributeFullName,
+                    "MyNamespace.Dummy1Attribute",
+                    "MyNamespace.Dummy2Attribute"
+                ) +
+                @"<Module file='$(InPath){2}{3}.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, output, Path.DirectorySeparatorChar, name);
+
+            TestHelper.BuildAndObfuscate(name, string.Empty, xml, true, Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7);
+            return Path.Combine(output, $"{name}.dll");
+        }
+
+        [Fact]
+        public void CheckAttributeArgumentIsPreserved()
+        {
+            var output = BuildAndObfuscateAssemblies();
+            AssemblyDefinition assmDef = AssemblyDefinition.ReadAssembly(output);
+
+            bool found = false;
+            foreach (TypeDefinition typeDef in assmDef.MainModule.Types)
+            {
+                if (typeDef.Name == "<Module>" || typeDef.FullName == SampleAttributeFullName)
+                    continue;                
+                else
+                    found = true;
+
+                var firstProperty = typeDef.Properties.FirstOrDefault(x => x.PropertyType.FullName == "System.Boolean");
+                var secondProperty = typeDef.Properties.FirstOrDefault(x => x.PropertyType.FullName == "System.String");
+
+                // both properties must exist
+                Assert.NotNull(firstProperty); 
+                Assert.NotNull(secondProperty);
+
+                // both properties are obfuscated
+                Assert.NotEqual("FirstProperty", firstProperty.Name);
+                Assert.NotEqual("SecondProperty", secondProperty.Name);
+
+                // second property should have CategoryAttribute
+                CustomAttribute attr = secondProperty.CustomAttributes.FirstOrDefault(x => x.AttributeType.FullName == SampleAttributeFullName);
+                Assert.NotNull(attr);
+
+                Assert.True(attr.ConstructorArguments.Count > 0); // "VisibleByAttribute should have parameters.");
+
+                // "VisibleByAttribute param should be an obfuscated name of first property.");
+                Assert.Equal(firstProperty.Name, attr.ConstructorArguments[0].Value);                
+            }
+
+            Assert.True(found, "Should have found non-<Module> type.");
+        }
+    }
+}


### PR DESCRIPTION
Added new settings and unit tests,
Please review my implementation of feature request #609..

New line for `configuration.rst`:
`CustomAttributesToPreservePropertyNames		List of custom attributes separated by `;` whose arguments should preserve property names, such as MyNamespace.VisibleByAttribute(string propertyName)`